### PR TITLE
fix: update import path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/r10r/crc16"
+	crc16 "github.com/i9si-sistemas/crc-16"
 )
 
 func main() {


### PR DESCRIPTION
The import path in the README was incorrect. This commit updates the import path to `github.com/i9si-sistemas/crc-16` to reflect the correct location of the package.